### PR TITLE
fix: add missing semicolon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN npm run build
 FROM nginx:alpine
 COPY --from=build /app/build /usr/share/nginx/html
 EXPOSE 80
-CMD ["nginx","-g","daemon off"]
+CMD ["nginx","-g","daemon off;"]


### PR DESCRIPTION
This PR adds the missing semicolon in the docker file for running the `nginx` server